### PR TITLE
[FEAT] Cadastro noticias no banco de dados #56

### DIFF
--- a/back-end/src/main/java/fatec/morpheus/controller/NewsController.java
+++ b/back-end/src/main/java/fatec/morpheus/controller/NewsController.java
@@ -3,12 +3,15 @@ package fatec.morpheus.controller;
 import java.sql.Date;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import fatec.morpheus.entity.News;
+import fatec.morpheus.entity.NewsReponse;
+import fatec.morpheus.entity.NewsSource;
 import fatec.morpheus.entity.PaginatedNewsResponse;
 import fatec.morpheus.service.NewsService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,6 +20,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 
@@ -34,25 +38,11 @@ public class NewsController {
         @ApiResponse(responseCode = "200", description = "Notícias retornadas com sucesso"),
         @ApiResponse(responseCode = "400", description = "Erro ao retornar notícias"),
     })
-
     @GetMapping
     public ResponseEntity<PaginatedNewsResponse> getAllNews(@RequestParam int page, @RequestParam(defaultValue = "50") int itens) {
         PaginatedNewsResponse news = newsService.getNewsWithDetails(page, itens);
         return ResponseEntity.ok(news);
     }
 
-        @PostMapping("/create")
-    public ResponseEntity<News> createNews(
-        @RequestParam String title, 
-        @RequestParam String content, 
-        @RequestParam(required = false) String autName, 
-        @RequestParam Date registryDate) {
-
-        // Chamar o service para salvar a notícia
-        News savedNews = newsService.saveNews(title, content, autName, registryDate);
-
-        // Retornar a notícia criada
-        return ResponseEntity.ok(savedNews);
-    }
 
 }

--- a/back-end/src/main/java/fatec/morpheus/controller/NewsController.java
+++ b/back-end/src/main/java/fatec/morpheus/controller/NewsController.java
@@ -1,11 +1,14 @@
 package fatec.morpheus.controller;
 
+import java.sql.Date;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import fatec.morpheus.entity.News;
 import fatec.morpheus.entity.PaginatedNewsResponse;
 import fatec.morpheus.service.NewsService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,6 +16,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 
@@ -35,6 +39,20 @@ public class NewsController {
     public ResponseEntity<PaginatedNewsResponse> getAllNews(@RequestParam int page, @RequestParam(defaultValue = "50") int itens) {
         PaginatedNewsResponse news = newsService.getNewsWithDetails(page, itens);
         return ResponseEntity.ok(news);
+    }
+
+        @PostMapping("/create")
+    public ResponseEntity<News> createNews(
+        @RequestParam String title, 
+        @RequestParam String content, 
+        @RequestParam(required = false) String autName, 
+        @RequestParam Date registryDate) {
+
+        // Chamar o service para salvar a notícia
+        News savedNews = newsService.saveNews(title, content, autName, registryDate);
+
+        // Retornar a notícia criada
+        return ResponseEntity.ok(savedNews);
     }
 
 }

--- a/back-end/src/main/java/fatec/morpheus/database/ddl.sql
+++ b/back-end/src/main/java/fatec/morpheus/database/ddl.sql
@@ -28,7 +28,7 @@ create table News(
 	new_title char(70),
     new_content text,
 	new_registry_date timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	new_aut_cod int,
+	new_aut_cod int NULL,
     new_src_cod int,
     FOREIGN KEY (new_aut_cod) REFERENCES News_author(new_aut_id),
     FOREIGN KEY (new_src_cod) REFERENCES Source(src_cod),

--- a/back-end/src/main/java/fatec/morpheus/entity/News.java
+++ b/back-end/src/main/java/fatec/morpheus/entity/News.java
@@ -29,19 +29,19 @@ public class News {
     @Column(name = "new_cod")
     private int newsCod;
 
-    @Column(name = "new_title", length = 70)
+    @Column(name = "new_title", length = 70, nullable = false)
     @Size(max = 70, message = "News Title cannot exceed 70 characters")
     private String newsTitle;
 
     @Column(name = "new_content")
     private String newsContent;
 
-    @Column(name = "new_registry_date", updatable = false)
+    @Column(name = "new_registry_date", updatable = false, nullable = false)
     @CreationTimestamp
     private Date newsRegistryDate;
 
     @ManyToOne
-    @JoinColumn(name = "new_aut_cod", referencedColumnName = "new_aut_id")
+    @JoinColumn(name = "new_aut_cod", referencedColumnName = "new_aut_id", nullable = true)
     private NewsAuthor newsAuthor;
 
     @ManyToOne

--- a/back-end/src/main/java/fatec/morpheus/entity/News.java
+++ b/back-end/src/main/java/fatec/morpheus/entity/News.java
@@ -43,7 +43,7 @@ public class News {
     @ManyToOne
     @JoinColumn(name = "new_aut_cod", referencedColumnName = "new_aut_id", nullable = true)
     private NewsAuthor newsAuthor;
-
+ 
     @ManyToOne
     @JoinColumn(name = "new_src_cod", referencedColumnName = "src_cod")
     private NewsSource sourceNews;

--- a/back-end/src/main/java/fatec/morpheus/entity/NewsSource.java
+++ b/back-end/src/main/java/fatec/morpheus/entity/NewsSource.java
@@ -29,7 +29,7 @@ public class NewsSource {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "src_cod")
-    private int code;
+    private Integer code;
 
     @Column(name = "src_name", length = 30, unique = true)
     @Size(max = 30, message = "Name cannot exceed 30 characters")

--- a/back-end/src/main/java/fatec/morpheus/repository/NewsAuthorRepository.java
+++ b/back-end/src/main/java/fatec/morpheus/repository/NewsAuthorRepository.java
@@ -1,11 +1,16 @@
 package fatec.morpheus.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import fatec.morpheus.entity.NewsAuthor;
 
+
 @Repository
 public interface NewsAuthorRepository extends JpaRepository<NewsAuthor, Integer>{
+
+    Optional<NewsAuthor> findByAutName(String autName);
     
 }

--- a/back-end/src/main/java/fatec/morpheus/repository/NewsAuthorRepository.java
+++ b/back-end/src/main/java/fatec/morpheus/repository/NewsAuthorRepository.java
@@ -12,5 +12,6 @@ import fatec.morpheus.entity.NewsAuthor;
 public interface NewsAuthorRepository extends JpaRepository<NewsAuthor, Integer>{
 
     Optional<NewsAuthor> findByAutName(String autName);
+    <S extends NewsAuthor> S save(S entity);
     
 }

--- a/back-end/src/main/java/fatec/morpheus/repository/NewsSourceRepository.java
+++ b/back-end/src/main/java/fatec/morpheus/repository/NewsSourceRepository.java
@@ -1,5 +1,7 @@
 package fatec.morpheus.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +12,5 @@ public interface NewsSourceRepository extends JpaRepository<NewsSource, Integer>
 
     boolean existsBySrcName(String srcName);
     boolean existsByAddress(String address);
+    Optional<NewsSource> findById(Integer id);
 }

--- a/back-end/src/main/java/fatec/morpheus/repository/SynonymousRepository.java
+++ b/back-end/src/main/java/fatec/morpheus/repository/SynonymousRepository.java
@@ -1,10 +1,12 @@
 package fatec.morpheus.repository;
 
 import fatec.morpheus.entity.Synonymous;
+import fatec.morpheus.entity.SynonymousId;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface SynonymousRepository extends JpaRepository<Synonymous, Integer> {
+public interface SynonymousRepository extends JpaRepository<Synonymous, SynonymousId> {
     void deleteByTextoCod(Integer textoCod);
 }

--- a/back-end/src/main/java/fatec/morpheus/service/NewsService.java
+++ b/back-end/src/main/java/fatec/morpheus/service/NewsService.java
@@ -3,6 +3,7 @@ package fatec.morpheus.service;
 import java.sql.Date;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -11,8 +12,10 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import fatec.morpheus.entity.News;
+import fatec.morpheus.entity.NewsAuthor;
 import fatec.morpheus.entity.NewsReponse;
 import fatec.morpheus.entity.PaginatedNewsResponse;
+import fatec.morpheus.repository.NewsAuthorRepository;
 import fatec.morpheus.repository.NewsRepository;
 
 @Service
@@ -20,6 +23,9 @@ public class NewsService {
 
     @Autowired
     private NewsRepository newsRepository;
+
+    @Autowired 
+    NewsAuthorRepository newsAuthorRepository;
     
     public PaginatedNewsResponse getNewsWithDetails(int page, int itens) {
         PageRequest pageable = PageRequest.of(page, itens, Sort.by(Sort.Direction.ASC, "newsRegistryDate"));
@@ -33,7 +39,7 @@ public class NewsService {
             String newsTitle = news.getNewsTitle();
             String newsContent = news.getNewsContent();
             Date newsRegistryDate = news.getNewsRegistryDate();
-            String autName = news.getNewsAuthor().getAutName();
+            String autName = (news.getNewsAuthor() != null) ? news.getNewsAuthor().getAutName() : "No author";
             String srcName = news.getSourceNews().getSrcName();
             String srcAddress = news.getSourceNews().getAddress();
             
@@ -46,6 +52,36 @@ public class NewsService {
             newsPage.getTotalPages(), 
             newsPage.getTotalElements()
         );
+    }
+
+    public News saveNews(String title, String content, String autName, Date registryDate) {
+
+        if (title == null || title.isEmpty()) {
+            throw new IllegalArgumentException("Title is required");
+        }
+    
+        if (registryDate == null) {
+            throw new IllegalArgumentException("Publication date is required");
+        }
+    
+        News news = new News();
+        
+        news.setNewsTitle(title);
+        news.setNewsContent(content);
+        news.setNewsRegistryDate(registryDate);
+        
+        if (autName != null && !autName.isEmpty()) {
+            Optional<NewsAuthor> newsAuthorOpt = newsAuthorRepository.findByAutName(autName);
+            if (newsAuthorOpt.isPresent()) {
+                news.setNewsAuthor(newsAuthorOpt.get());
+            } else {
+                throw new IllegalArgumentException("Author not found");
+            }
+        } else {
+            news.setNewsAuthor(null); 
+        }
+    
+        return newsRepository.save(news);
     }
 
     

--- a/back-end/src/main/java/fatec/morpheus/service/NewsSourceService.java
+++ b/back-end/src/main/java/fatec/morpheus/service/NewsSourceService.java
@@ -102,7 +102,6 @@ public class NewsSourceService {
     
 
     public NewsSource deleteNewsSourceById(int id) {
-        return newsSourceRepository.findById(id)
-                    .orElseThrow(() -> new NotFoundException(id));
+        return newsSourceRepository.findById(id).orElseThrow(() -> new NotFoundException(id));
     }
 }

--- a/back-end/src/main/resources/application.properties
+++ b/back-end/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 spring.datasource.url=jdbc:mysql://localhost:3306/morpheus
 spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.password=1234
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 

--- a/back-end/src/test/java/fatec/morpheus/MorpheusApplicationTests.java
+++ b/back-end/src/test/java/fatec/morpheus/MorpheusApplicationTests.java
@@ -1,13 +1,116 @@
 package fatec.morpheus;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Date;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 // import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import fatec.morpheus.entity.News;
+import fatec.morpheus.entity.NewsAuthor;
+import fatec.morpheus.repository.NewsAuthorRepository;
+import fatec.morpheus.repository.NewsRepository;
+import fatec.morpheus.service.NewsService;
 
 @SpringBootTest
 class MorpheusApplicationTests {
 
-	// @Test
-	// void contextLoads() {
-	// }
+   @Mock
+    private NewsRepository newsRepository;  // Simula o repositório de News
+
+    @Mock
+    private NewsAuthorRepository newsAuthorRepository;  // Simula o repositório de NewsAuthor
+
+    @InjectMocks
+    private NewsService newsService;  // A classe de serviço que estamos testando
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);  // Inicializa os mocks antes de cada teste
+    }
+
+	@Test
+	public void testSaveNews_Success() {
+		// Dados de entrada
+		String title = "Sample Title";
+		String content = "Sample Content";
+		String autName = "John Doe";
+		Date registryDate = new Date(System.currentTimeMillis());
+	
+		// Mockar o comportamento do repositório de autor
+		NewsAuthor author = new NewsAuthor();
+		author.setAutName(autName);
+		when(newsAuthorRepository.findByAutName(autName)).thenReturn(Optional.of(author));
+	
+		// Mockar o comportamento do repositório de notícias
+		News news = new News();
+		news.setNewsTitle(title);
+		news.setNewsContent(content);
+		news.setNewsAuthor(author); // Associa o autor ao mock de notícia
+		news.setNewsRegistryDate(registryDate);
+		when(newsRepository.save(any(News.class))).thenReturn(news);
+		
+	
+		// Executar o método de teste
+		News savedNews = newsService.saveNews(title, content, autName, registryDate);
+	
+		// Verificar se a notícia foi salva corretamente
+		assertNotNull(savedNews);
+		assertEquals(title, savedNews.getNewsTitle());
+		assertEquals(content, savedNews.getNewsContent());
+		assertEquals(autName, savedNews.getNewsAuthor().getAutName());
+		assertEquals(registryDate, savedNews.getNewsRegistryDate());
+	
+		// Verificar se os métodos mockados foram chamados
+		verify(newsAuthorRepository, times(1)).findByAutName(autName);
+		verify(newsRepository, times(1)).save(any(News.class));
+	}
+	
+    @Test
+    public void testSaveNews_MissingTitle() {
+        // Definir dados de entrada com título faltando
+        String content = "Sample Content";
+        String autName = "John Doe";
+        Date registryDate = new Date(System.currentTimeMillis());
+
+        // Verificar se a exceção é lançada ao tentar salvar notícia sem título
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            newsService.saveNews(null, content, autName, registryDate);
+        });
+
+        assertEquals("Title is required", exception.getMessage());
+    }
+
+    @Test
+    public void testSaveNews_AuthorNotFound() {
+        // Dados de entrada com autor não existente
+        String title = "Sample Title";
+        String content = "Sample Content";
+        String autName = "Unknown Author";
+        Date registryDate = new Date(System.currentTimeMillis());
+
+        // Mockar o comportamento do repositório de autor para retornar vazio
+        when(newsAuthorRepository.findByAutName(autName)).thenReturn(Optional.empty());
+
+        // Verificar se a exceção é lançada quando o autor não é encontrado
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            newsService.saveNews(title, content, autName, registryDate);
+        });
+
+        assertEquals("Author not found", exception.getMessage());
+    }
 
 }

--- a/back-end/src/test/java/fatec/morpheus/MorpheusApplicationTests.java
+++ b/back-end/src/test/java/fatec/morpheus/MorpheusApplicationTests.java
@@ -1,116 +1,33 @@
 package fatec.morpheus;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.sql.Date;
-import java.util.Optional;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-// import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
 
 import fatec.morpheus.entity.News;
-import fatec.morpheus.entity.NewsAuthor;
-import fatec.morpheus.repository.NewsAuthorRepository;
-import fatec.morpheus.repository.NewsRepository;
 import fatec.morpheus.service.NewsService;
 
-@SpringBootTest
-class MorpheusApplicationTests {
+import java.sql.Date;
 
-   @Mock
-    private NewsRepository newsRepository;  // Simula o repositório de News
+@Component
+public class NewsRunner implements CommandLineRunner {
 
-    @Mock
-    private NewsAuthorRepository newsAuthorRepository;  // Simula o repositório de NewsAuthor
+    @Autowired
+    private NewsService newsService;
 
-    @InjectMocks
-    private NewsService newsService;  // A classe de serviço que estamos testando
-
-    @BeforeEach
-    public void setUp() {
-        MockitoAnnotations.initMocks(this);  // Inicializa os mocks antes de cada teste
-    }
-
-	@Test
-	public void testSaveNews_Success() {
-		// Dados de entrada
-		String title = "Sample Title";
-		String content = "Sample Content";
-		String autName = "John Doe";
-		Date registryDate = new Date(System.currentTimeMillis());
-	
-		// Mockar o comportamento do repositório de autor
-		NewsAuthor author = new NewsAuthor();
-		author.setAutName(autName);
-		when(newsAuthorRepository.findByAutName(autName)).thenReturn(Optional.of(author));
-	
-		// Mockar o comportamento do repositório de notícias
-		News news = new News();
-		news.setNewsTitle(title);
-		news.setNewsContent(content);
-		news.setNewsAuthor(author); // Associa o autor ao mock de notícia
-		news.setNewsRegistryDate(registryDate);
-		when(newsRepository.save(any(News.class))).thenReturn(news);
-		
-	
-		// Executar o método de teste
-		News savedNews = newsService.saveNews(title, content, autName, registryDate);
-	
-		// Verificar se a notícia foi salva corretamente
-		assertNotNull(savedNews);
-		assertEquals(title, savedNews.getNewsTitle());
-		assertEquals(content, savedNews.getNewsContent());
-		assertEquals(autName, savedNews.getNewsAuthor().getAutName());
-		assertEquals(registryDate, savedNews.getNewsRegistryDate());
-	
-		// Verificar se os métodos mockados foram chamados
-		verify(newsAuthorRepository, times(1)).findByAutName(autName);
-		verify(newsRepository, times(1)).save(any(News.class));
-	}
-	
-    @Test
-    public void testSaveNews_MissingTitle() {
-        // Definir dados de entrada com título faltando
-        String content = "Sample Content";
-        String autName = "John Doe";
+    @Override
+    public void run(String... args) throws Exception {
+        // Dados de exemplo
+        String title = "Título de Exemplo";
+        String content = "Conteúdo da notícia de exemplo.";
+        String author = "Autor de Exemplo";
         Date registryDate = new Date(System.currentTimeMillis());
+        Integer sourceId = 1; // ID da fonte de notícia já existente no banco
 
-        // Verificar se a exceção é lançada ao tentar salvar notícia sem título
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            newsService.saveNews(null, content, autName, registryDate);
-        });
+        // Chama o método de salvar
+        News savedNews = newsService.saveNews(title, content, author, registryDate, sourceId);
 
-        assertEquals("Title is required", exception.getMessage());
+        // Exibe o resultado
+        System.out.println("Notícia salva com ID: " + savedNews.getNewsCod());
     }
-
-    @Test
-    public void testSaveNews_AuthorNotFound() {
-        // Dados de entrada com autor não existente
-        String title = "Sample Title";
-        String content = "Sample Content";
-        String autName = "Unknown Author";
-        Date registryDate = new Date(System.currentTimeMillis());
-
-        // Mockar o comportamento do repositório de autor para retornar vazio
-        when(newsAuthorRepository.findByAutName(autName)).thenReturn(Optional.empty());
-
-        // Verificar se a exceção é lançada quando o autor não é encontrado
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            newsService.saveNews(title, content, autName, registryDate);
-        });
-
-        assertEquals("Author not found", exception.getMessage());
-    }
-
 }


### PR DESCRIPTION
O que foi feito:
definido a tabela noticias no banco de dados com os campos: id, título, conteúdo, autor e data de publicação.


Implementado as restrições necessárias para garantir a integridade dos dados, como a obrigatoriedade de título e data de publicação.


Criado um serviço que receba as informações de uma notícia (título, conteúdo, autor e data de publicação) e realize o cadastro no banco de dados.