### PR TITLE
[Feat] Endpoint filtro de notícias #89

### DIFF
--- a/back-end/src/main/java/fatec/morpheus/controller/NewsFilterController.java
+++ b/back-end/src/main/java/fatec/morpheus/controller/NewsFilterController.java
@@ -1,6 +1,8 @@
 package fatec.morpheus.controller;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -8,7 +10,9 @@ import fatec.morpheus.entity.NewsReponse;
 import fatec.morpheus.service.NewsService;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/morpheus/NewsFilter")
@@ -18,15 +22,25 @@ public class NewsFilterController {
     private NewsService newsService;
 
     @GetMapping("/search")
-    public ResponseEntity<List<NewsReponse>> getNoticias(
-        @RequestParam(required = false) List<String> titles,
-        @RequestParam(required = false) List<String> contents,
-        @RequestParam(required = false) List<String> authors,
-        @RequestParam(required = false) List<String> portals,
-        @RequestParam(required = false) LocalDate dataStart,
-        @RequestParam(required = false) LocalDate dataEnd) {
-    
-        List<NewsReponse> noticias = newsService.buscarNoticiasComFiltros(titles, contents, authors, portals, dataStart, dataEnd);
-        return ResponseEntity.ok(noticias);
+    public ResponseEntity<Map<String, Object>> buscarNoticiasComFiltros(
+            @RequestParam(required = false) List<String> titles,
+            @RequestParam(required = false) List<String> contents,
+            @RequestParam(required = false) List<String> authors,
+            @RequestParam(required = false) List<String> portals,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataStart,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dataEnd,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "50") int items) {
+
+
+        PageRequest pageRequest = PageRequest.of(page - 1, items);
+        Page<NewsReponse> newsPage = newsService.buscarNoticiasComFiltros(titles, contents, authors, portals, dataStart, dataEnd, pageRequest);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("news", newsPage.getContent());
+        response.put("totalItems", newsPage.getTotalElements());
+        response.put("totalPages", newsPage.getTotalPages());
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/back-end/src/main/java/fatec/morpheus/controller/NewsFilterController.java
+++ b/back-end/src/main/java/fatec/morpheus/controller/NewsFilterController.java
@@ -17,22 +17,16 @@ public class NewsFilterController {
     @Autowired
     private NewsService newsService;
 
-
     @GetMapping("/search")
-    public ResponseEntity<List<NewsReponse>> searchNews(
-            @RequestParam(required = false) List<String> titles,
-            @RequestParam(required = false) List<String> contents,
-            @RequestParam(required = false) List<String> authors,
-            @RequestParam(required = false) List<String> portals,
-            @RequestParam(required = false) LocalDate dataStart,
-            @RequestParam(required = false) LocalDate dataEnd) {
-        
+    public ResponseEntity<List<NewsReponse>> getNoticias(
+        @RequestParam(required = false) List<String> titles,
+        @RequestParam(required = false) List<String> contents,
+        @RequestParam(required = false) List<String> authors,
+        @RequestParam(required = false) List<String> portals,
+        @RequestParam(required = false) LocalDate dataStart,
+        @RequestParam(required = false) LocalDate dataEnd) {
+    
         List<NewsReponse> noticias = newsService.buscarNoticiasComFiltros(titles, contents, authors, portals, dataStart, dataEnd);
-        
-        if (noticias.isEmpty()) {
-            return new ResponseEntity<>(HttpStatus.NO_CONTENT); 
-        }
-        
-        return new ResponseEntity<>(noticias, HttpStatus.OK);
+        return ResponseEntity.ok(noticias);
     }
 }

--- a/back-end/src/main/java/fatec/morpheus/controller/NewsFilterController.java
+++ b/back-end/src/main/java/fatec/morpheus/controller/NewsFilterController.java
@@ -1,0 +1,36 @@
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import fatec.morpheus.entity.NewsReponse;
+import fatec.morpheus.service.NewsService;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/morpheus/NewsFilter")
+public class NewsFilterController {
+
+    @Autowired
+    private NewsService newsService;
+
+    @GetMapping("/search")
+    public ResponseEntity<List<NewsReponse>> searchNews(
+            @RequestParam(required = false) String titulo,
+            @RequestParam(required = false) String conteudo,
+            @RequestParam(required = false) String autor,
+            @RequestParam(required = false) String portal,
+            @RequestParam(required = false) LocalDate dataInicio,
+            @RequestParam(required = false) LocalDate dataFim) {
+        
+        List<NewsReponse> noticias = newsService.buscarNoticiasComFiltros(titulo, conteudo, autor, portal, dataInicio, dataFim);
+        
+        if (noticias.isEmpty()) {
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT); 
+        }
+        
+        return new ResponseEntity<>(noticias, HttpStatus.OK); // 
+    }
+}

--- a/back-end/src/main/java/fatec/morpheus/controller/NewsFilterController.java
+++ b/back-end/src/main/java/fatec/morpheus/controller/NewsFilterController.java
@@ -1,3 +1,4 @@
+package fatec.morpheus.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,21 +17,22 @@ public class NewsFilterController {
     @Autowired
     private NewsService newsService;
 
+
     @GetMapping("/search")
     public ResponseEntity<List<NewsReponse>> searchNews(
-            @RequestParam(required = false) String titulo,
-            @RequestParam(required = false) String conteudo,
-            @RequestParam(required = false) String autor,
-            @RequestParam(required = false) String portal,
-            @RequestParam(required = false) LocalDate dataInicio,
-            @RequestParam(required = false) LocalDate dataFim) {
+            @RequestParam(required = false) List<String> titles,
+            @RequestParam(required = false) List<String> contents,
+            @RequestParam(required = false) List<String> authors,
+            @RequestParam(required = false) List<String> portals,
+            @RequestParam(required = false) LocalDate dataStart,
+            @RequestParam(required = false) LocalDate dataEnd) {
         
-        List<NewsReponse> noticias = newsService.buscarNoticiasComFiltros(titulo, conteudo, autor, portal, dataInicio, dataFim);
+        List<NewsReponse> noticias = newsService.buscarNoticiasComFiltros(titles, contents, authors, portals, dataStart, dataEnd);
         
         if (noticias.isEmpty()) {
             return new ResponseEntity<>(HttpStatus.NO_CONTENT); 
         }
         
-        return new ResponseEntity<>(noticias, HttpStatus.OK); // 
+        return new ResponseEntity<>(noticias, HttpStatus.OK);
     }
 }

--- a/back-end/src/main/java/fatec/morpheus/controller/NewsFilterController.java
+++ b/back-end/src/main/java/fatec/morpheus/controller/NewsFilterController.java
@@ -8,6 +8,9 @@ import org.springframework.web.bind.annotation.*;
 
 import fatec.morpheus.entity.NewsReponse;
 import fatec.morpheus.service.NewsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 import java.time.LocalDate;
 import java.util.HashMap;
@@ -21,6 +24,12 @@ public class NewsFilterController {
     @Autowired
     private NewsService newsService;
 
+
+        @Operation(summary = "Filtro Notícias", description = "Retorna notícias relacionadas aos parâmetros a serem inseridos")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Notícias retornadas com sucesso"),
+        @ApiResponse(responseCode = "400", description = "Termo especificado não encontrado"),
+    })
     @GetMapping("/search")
     public ResponseEntity<Map<String, Object>> buscarNoticiasComFiltros(
             @RequestParam(required = false) List<String> titles,

--- a/back-end/src/main/java/fatec/morpheus/database/ddl.sql
+++ b/back-end/src/main/java/fatec/morpheus/database/ddl.sql
@@ -37,7 +37,7 @@ create table Source_tag(
 create table News(
 	new_cod int auto_increment,
 	new_title char(70),
-   
+	new_content text,
 	new_registry_date timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	new_aut_cod int,
     new_src_cod int,

--- a/back-end/src/main/java/fatec/morpheus/entity/PaginatedNewsResponse.java
+++ b/back-end/src/main/java/fatec/morpheus/entity/PaginatedNewsResponse.java
@@ -12,8 +12,8 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class PaginatedNewsResponse {
-    private List<NewsReponse> news;
+public class PaginatedNewsResponse<T> {
+    private List<T> news;
     private int totalPages;
     private long totalElements;
 }

--- a/back-end/src/main/java/fatec/morpheus/exception/CustomNotFoundException.java
+++ b/back-end/src/main/java/fatec/morpheus/exception/CustomNotFoundException.java
@@ -1,0 +1,17 @@
+package fatec.morpheus.exception;
+
+import fatec.morpheus.entity.ErrorResponse;
+
+public class CustomNotFoundException extends RuntimeException {
+    private final ErrorResponse errorResponse;
+
+    public CustomNotFoundException(ErrorResponse errorResponse) {
+        super(errorResponse.getMessage());
+        this.errorResponse = errorResponse;
+    }
+
+    public ErrorResponse getErrorResponse() {
+        return errorResponse;
+    }
+}
+

--- a/back-end/src/main/java/fatec/morpheus/exception/GlobalExceptionHandler.java
+++ b/back-end/src/main/java/fatec/morpheus/exception/GlobalExceptionHandler.java
@@ -17,6 +17,11 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(ex.getErrorResponse(), HttpStatus.NOT_FOUND);
     }
 
+    @ExceptionHandler(CustomNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleCustomNotFound(CustomNotFoundException ex) { 
+        return new ResponseEntity<>(ex.getErrorResponse(), HttpStatus.NOT_FOUND);
+    }
+
     @ExceptionHandler(UniqueConstraintViolationException.class)
     public ResponseEntity<ErrorResponse> handleUniqueConstraint(UniqueConstraintViolationException ex) {
         return new ResponseEntity<>(ex.getErrorResponse(), HttpStatus.CONFLICT);

--- a/back-end/src/main/java/fatec/morpheus/repository/NewsRepository.java
+++ b/back-end/src/main/java/fatec/morpheus/repository/NewsRepository.java
@@ -3,13 +3,14 @@ package fatec.morpheus.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import fatec.morpheus.entity.News;
 import io.micrometer.common.lang.NonNull;
 
 @Repository
-public interface NewsRepository extends JpaRepository<News, Integer>{
+public interface NewsRepository extends JpaRepository<News, Integer>, JpaSpecificationExecutor<News>{
 
     Page<News> findAll(@NonNull Pageable Pegeable);
     boolean existsByNewAddress(String newAddress);

--- a/back-end/src/main/java/fatec/morpheus/service/NewsService.java
+++ b/back-end/src/main/java/fatec/morpheus/service/NewsService.java
@@ -1,8 +1,10 @@
 package fatec.morpheus.service;
 
 import java.sql.Date;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -12,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import fatec.morpheus.entity.News;
 import fatec.morpheus.entity.NewsReponse;
+import fatec.morpheus.entity.NewsSource;
 import fatec.morpheus.entity.PaginatedNewsResponse;
 import fatec.morpheus.repository.NewsRepository;
 import fatec.morpheus.repository.NewsSourceRepository;
@@ -68,4 +71,48 @@ public class NewsService {
         return newsSourceRepository.existsByAddress(address);
     }
 
+    // public List<NewsReponse> buscarNoticiasComFiltros(String titulo, String conteudo, String autor, String portal, LocalDate dataInicio, LocalDate dataFim) {
+    //     return newsRepository
+    //             .findAll(NewsSpecification.comFiltros(titulo, conteudo, autor, portal, dataInicio, dataFim)) // Chamada ajustada
+    //             .stream()
+    //             .map(news -> new NewsReponse( 
+    //                 news.getNewsTitle(),
+    //                 news.getNewsContent(),
+    //                 news.getNewsRegistryDate(),
+    //                 getAuthorName(news),
+    //                 news.getSourceNews().getSrcName(),
+    //                 news.getSourceNews().getAddress(),
+    //                 news.getNewAddress()
+    //             ))
+    //             .collect(Collectors.toList());
+    // }
+
+    public List<NewsReponse> buscarNoticiasComFiltros(String titulo, String conteudo, String autor, String portal, LocalDate dataInicio, LocalDate dataFim) {
+        return newsRepository
+                .findAll(NewsSpecification.comFiltros(titulo, conteudo, autor, portal, dataInicio, dataFim))
+                .stream()
+                .map(news -> {
+                    List<String> srcNames = news.getSourceNews().stream()
+                            .map(NewsSource::getSrcName) // Recupera o nome da fonte
+                            .distinct() // Remove duplicatas, se necessário
+                            .collect(Collectors.toList());
+    
+                    List<String> srcAddresses = news.getSourceNews().stream()
+                            .map(NewsSource::getAddress) // Recupera o endereço da fonte
+                            .distinct() // Remove duplicatas, se necessário
+                            .collect(Collectors.toList());
+    
+                    return new NewsReponse(
+                        news.getNewsTitle(),
+                        news.getNewsContent(),
+                        news.getNewsRegistryDate(),
+                        getAuthorName(news),
+                        srcNames,
+                        srcAddresses,
+                        news.getNewAddress()
+                    );
+                })
+                .collect(Collectors.toList());
+    }
+    
 }

--- a/back-end/src/main/java/fatec/morpheus/service/NewsService.java
+++ b/back-end/src/main/java/fatec/morpheus/service/NewsService.java
@@ -69,23 +69,25 @@ public class NewsService {
     }
 
     public List<NewsReponse> buscarNoticiasComFiltros(List<String> titles, List<String> contents, List<String> authors, List<String> portals, LocalDate dataStart, LocalDate dataEnd) {
-        List<News> noticias = newsRepository.findAll(NewsSpecification.comFiltros(titles, contents, authors, portals, dataStart, dataEnd));
+        List<News> listNews = newsRepository.findAll(NewsSpecification.comFiltros(titles, contents, authors, portals, dataStart, dataEnd));
     
-        return noticias.stream()
-                .map(news -> {
-                    String srcName = news.getSourceNews().getSrcName();
-                    String srcAddress = news.getSourceNews().getAddress();
-    
-                    return new NewsReponse(
-                        news.getNewsTitle(),
-                        news.getNewsContent(),
-                        news.getNewsRegistryDate(),
-                        getAuthorName(news),
-                        srcName,
-                        srcAddress,
-                        news.getNewAddress()
-                    );
-                })
-                .collect(Collectors.toList());
+        return listNews.stream()
+        .map((News news) -> {
+            String srcName = news.getSourceNews().getSrcName();
+            String srcAddress = news.getSourceNews().getAddress();
+
+            return new NewsReponse(
+                news.getNewsTitle(),
+                news.getNewsContent(),
+                news.getNewsRegistryDate(),
+                getAuthorName(news),
+                srcName,
+                srcAddress,
+                news.getNewAddress()
+            );
+        })
+        .collect(Collectors.toList());
     }
+    
+    
 }

--- a/back-end/src/main/java/fatec/morpheus/service/NewsService.java
+++ b/back-end/src/main/java/fatec/morpheus/service/NewsService.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -14,11 +13,9 @@ import org.springframework.stereotype.Service;
 
 import fatec.morpheus.entity.News;
 import fatec.morpheus.entity.NewsReponse;
-import fatec.morpheus.entity.NewsSource;
 import fatec.morpheus.entity.PaginatedNewsResponse;
 import fatec.morpheus.repository.NewsRepository;
 import fatec.morpheus.repository.NewsSourceRepository;
-
 @Service
 public class NewsService {
 
@@ -71,48 +68,24 @@ public class NewsService {
         return newsSourceRepository.existsByAddress(address);
     }
 
-    // public List<NewsReponse> buscarNoticiasComFiltros(String titulo, String conteudo, String autor, String portal, LocalDate dataInicio, LocalDate dataFim) {
-    //     return newsRepository
-    //             .findAll(NewsSpecification.comFiltros(titulo, conteudo, autor, portal, dataInicio, dataFim)) // Chamada ajustada
-    //             .stream()
-    //             .map(news -> new NewsReponse( 
-    //                 news.getNewsTitle(),
-    //                 news.getNewsContent(),
-    //                 news.getNewsRegistryDate(),
-    //                 getAuthorName(news),
-    //                 news.getSourceNews().getSrcName(),
-    //                 news.getSourceNews().getAddress(),
-    //                 news.getNewAddress()
-    //             ))
-    //             .collect(Collectors.toList());
-    // }
-
-    public List<NewsReponse> buscarNoticiasComFiltros(String titulo, String conteudo, String autor, String portal, LocalDate dataInicio, LocalDate dataFim) {
-        return newsRepository
-                .findAll(NewsSpecification.comFiltros(titulo, conteudo, autor, portal, dataInicio, dataFim))
-                .stream()
-                .map(news -> {
-                    List<String> srcNames = news.getSourceNews().stream()
-                            .map(NewsSource::getSrcName) // Recupera o nome da fonte
-                            .distinct() // Remove duplicatas, se necessário
-                            .collect(Collectors.toList());
+    public List<NewsReponse> buscarNoticiasComFiltros(List<String> titles, List<String> contents, List<String> authors, List<String> portals, LocalDate dataStart, LocalDate dataEnd) {
+        List<News> noticias = newsRepository.findAll(NewsSpecification.comFiltros(titles, contents, authors, portals, dataStart, dataEnd));
     
-                    List<String> srcAddresses = news.getSourceNews().stream()
-                            .map(NewsSource::getAddress) // Recupera o endereço da fonte
-                            .distinct() // Remove duplicatas, se necessário
-                            .collect(Collectors.toList());
+        return noticias.stream()
+                .map(news -> {
+                    String srcName = news.getSourceNews().getSrcName();
+                    String srcAddress = news.getSourceNews().getAddress();
     
                     return new NewsReponse(
                         news.getNewsTitle(),
                         news.getNewsContent(),
                         news.getNewsRegistryDate(),
                         getAuthorName(news),
-                        srcNames,
-                        srcAddresses,
+                        srcName,
+                        srcAddress,
                         news.getNewAddress()
                     );
                 })
                 .collect(Collectors.toList());
     }
-    
 }

--- a/back-end/src/main/java/fatec/morpheus/service/NewsSpecification.java
+++ b/back-end/src/main/java/fatec/morpheus/service/NewsSpecification.java
@@ -33,7 +33,7 @@ public class NewsSpecification {
             if (authors != null && !authors.isEmpty()) {
                 Predicate authorPredicate = criteriaBuilder.disjunction();
                 for (String author : authors) {
-                    authorPredicate = criteriaBuilder.or(authorPredicate, criteriaBuilder.like(root.get("newsAuthor").get("autName"), "%" + author + "%"));
+                    authorPredicate = criteriaBuilder.or(authorPredicate, criteriaBuilder.like(root.join("newsAuthor").get("new_aut_name"), "%" + author + "%"));
                 }
                 predicate = criteriaBuilder.and(predicate, authorPredicate);
             }
@@ -41,7 +41,7 @@ public class NewsSpecification {
             if (portals != null && !portals.isEmpty()) {
                 Predicate sourcePredicate = criteriaBuilder.disjunction();
                 for (String portal : portals) {
-                    sourcePredicate = criteriaBuilder.or(sourcePredicate, criteriaBuilder.like(root.get("sourceNews").get("srcName"), "%" + portal + "%"));
+                    sourcePredicate = criteriaBuilder.or(sourcePredicate, criteriaBuilder.like(root.join("sourceNews").get("srcName"), "%" + portal + "%"));
                 }
                 predicate = criteriaBuilder.and(predicate, sourcePredicate);
             }
@@ -53,6 +53,7 @@ public class NewsSpecification {
             return predicate;
         };
     }
+    
     
 
 }

--- a/back-end/src/main/java/fatec/morpheus/service/NewsSpecification.java
+++ b/back-end/src/main/java/fatec/morpheus/service/NewsSpecification.java
@@ -2,6 +2,7 @@ package fatec.morpheus.service;
 
 import java.time.LocalDate;
 
+import java.util.List;
 import org.springframework.data.jpa.domain.Specification;
 
 import fatec.morpheus.entity.News;
@@ -9,31 +10,49 @@ import jakarta.persistence.criteria.Predicate;
 
 public class NewsSpecification {
 
-    public static Specification<News> comFiltros(String titulo, String conteudo, String autor, String portal, LocalDate dataInicio, LocalDate dataFim) {
+    public static Specification<News> comFiltros(List<String> titles, List<String> contents, List<String> authors, List<String> portals, LocalDate dataStart, LocalDate dataEnd) {
         return (root, query, criteriaBuilder) -> {
             Predicate predicate = criteriaBuilder.conjunction();
-
-            if (titulo != null && !titulo.isEmpty()) {
-                predicate = criteriaBuilder.and(predicate, criteriaBuilder.like(root.get("newsTitle"), "%" + titulo + "%"));
+    
+            if (titles != null && !titles.isEmpty()) {
+                Predicate titlePredicate = criteriaBuilder.disjunction();
+                for (String title : titles) {
+                    titlePredicate = criteriaBuilder.or(titlePredicate, criteriaBuilder.like(root.get("newsTitle"), "%" + title + "%"));
+                }
+                predicate = criteriaBuilder.and(predicate, titlePredicate);
             }
-
-            if (conteudo != null && !conteudo.isEmpty()) {
-                predicate = criteriaBuilder.and(predicate, criteriaBuilder.like(root.get("newsContent"), "%" + conteudo + "%"));
+    
+            if (contents != null && !contents.isEmpty()) {
+                Predicate contentPredicate = criteriaBuilder.disjunction();
+                for (String content : contents) {
+                    contentPredicate = criteriaBuilder.or(contentPredicate, criteriaBuilder.like(root.get("newsContent"), "%" + content + "%"));
+                }
+                predicate = criteriaBuilder.and(predicate, contentPredicate);
             }
-
-            if (autor != null && !autor.isEmpty()) {
-                predicate = criteriaBuilder.and(predicate, criteriaBuilder.like(root.get("newsAuthor").get("autName"), "%" + autor + "%"));
+    
+            if (authors != null && !authors.isEmpty()) {
+                Predicate authorPredicate = criteriaBuilder.disjunction();
+                for (String author : authors) {
+                    authorPredicate = criteriaBuilder.or(authorPredicate, criteriaBuilder.like(root.get("newsAuthor").get("autName"), "%" + author + "%"));
+                }
+                predicate = criteriaBuilder.and(predicate, authorPredicate);
             }
-
-            if (portal != null && !portal.isEmpty()) {
-                predicate = criteriaBuilder.and(predicate, criteriaBuilder.like(root.get("sourceNews").get("srcName"), "%" + portal + "%"));
+    
+            if (portals != null && !portals.isEmpty()) {
+                Predicate sourcePredicate = criteriaBuilder.disjunction();
+                for (String portal : portals) {
+                    sourcePredicate = criteriaBuilder.or(sourcePredicate, criteriaBuilder.like(root.get("sourceNews").get("srcName"), "%" + portal + "%"));
+                }
+                predicate = criteriaBuilder.and(predicate, sourcePredicate);
             }
-
-            if (dataInicio != null && dataFim != null) {
-                predicate = criteriaBuilder.and(predicate, criteriaBuilder.between(root.get("newsRegistryDate"), dataInicio, dataFim));
+    
+            if (dataStart != null && dataEnd != null) {
+                predicate = criteriaBuilder.and(predicate, criteriaBuilder.between(root.get("newsRegistryDate"), dataStart, dataEnd));
             }
-
+    
             return predicate;
         };
     }
+    
+
 }

--- a/back-end/src/main/java/fatec/morpheus/service/NewsSpecification.java
+++ b/back-end/src/main/java/fatec/morpheus/service/NewsSpecification.java
@@ -1,0 +1,39 @@
+package fatec.morpheus.service;
+
+import java.time.LocalDate;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import fatec.morpheus.entity.News;
+import jakarta.persistence.criteria.Predicate;
+
+public class NewsSpecification {
+
+    public static Specification<News> comFiltros(String titulo, String conteudo, String autor, String portal, LocalDate dataInicio, LocalDate dataFim) {
+        return (root, query, criteriaBuilder) -> {
+            Predicate predicate = criteriaBuilder.conjunction();
+
+            if (titulo != null && !titulo.isEmpty()) {
+                predicate = criteriaBuilder.and(predicate, criteriaBuilder.like(root.get("newsTitle"), "%" + titulo + "%"));
+            }
+
+            if (conteudo != null && !conteudo.isEmpty()) {
+                predicate = criteriaBuilder.and(predicate, criteriaBuilder.like(root.get("newsContent"), "%" + conteudo + "%"));
+            }
+
+            if (autor != null && !autor.isEmpty()) {
+                predicate = criteriaBuilder.and(predicate, criteriaBuilder.like(root.get("newsAuthor").get("autName"), "%" + autor + "%"));
+            }
+
+            if (portal != null && !portal.isEmpty()) {
+                predicate = criteriaBuilder.and(predicate, criteriaBuilder.like(root.get("sourceNews").get("srcName"), "%" + portal + "%"));
+            }
+
+            if (dataInicio != null && dataFim != null) {
+                predicate = criteriaBuilder.and(predicate, criteriaBuilder.between(root.get("newsRegistryDate"), dataInicio, dataFim));
+            }
+
+            return predicate;
+        };
+    }
+}


### PR DESCRIPTION
Criação do Endpoint:


Definir a rota para o endpoint de busca de notícias com filtros.


Configurar a recepção dos parâmetros de filtro (título, conteúdo, autores, datas, portais e textos).

Integração da Query:


Integrar a query de busca ao endpoint, garantindo que todos os filtros sejam aplicados corretamente.


Realizar testes com a query para verificar se os filtros estão sendo aplicados como esperado.

Paginação dos Resultados:


Implementar a funcionalidade de paginação nos resultados retornados pelo endpoint.


Adicionar metadados na resposta, como o número de páginas e o total de resultados.

Tratamento de Erros:


Implementar validações dos parâmetros recebidos e garantir que todos estejam corretos antes de executar a query.


Configurar mensagens de erro apropriadas para casos de parâmetros inválidos ou ausência de resultados.

Documentação:


Atualizar a documentação do endpoint no swagger.


Adicionar mensagens de erro amigáveis ao usuário.