### PR TITLE
[E- F][Filtragem de Notícias] Filtro de tags #101

### DIFF
--- a/back-end/src/main/java/fatec/morpheus/DTO/TagDTO.java
+++ b/back-end/src/main/java/fatec/morpheus/DTO/TagDTO.java
@@ -1,0 +1,15 @@
+package fatec.morpheus.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+@Getter
+@Setter
+@AllArgsConstructor
+public class TagDTO {
+    private Integer id;
+    private String name;
+    private Integer newsCount;
+}

--- a/back-end/src/main/java/fatec/morpheus/controller/TagFilterController.java
+++ b/back-end/src/main/java/fatec/morpheus/controller/TagFilterController.java
@@ -1,0 +1,39 @@
+package fatec.morpheus.controller;
+
+import fatec.morpheus.DTO.TagDTO;
+import fatec.morpheus.service.TagService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@CrossOrigin("*")
+@RestController
+@RequestMapping("/morpheus/tag")
+public class TagFilterController {
+
+    @Autowired
+    private TagService tagService;
+
+    @PostMapping("/search")
+    public ResponseEntity<?> filterTags(@RequestBody List<String> newsSource) {
+        if (newsSource == null || newsSource.isEmpty()) {
+            return ResponseEntity.badRequest().body("A lista de portais não pode estar vazia.");
+        }
+
+        List<Object[]> tags = tagService.findTagWithSource(newsSource);
+
+        List<Map<String, Object>> tagsList = tags.stream()
+                .map(tag -> Map.of(
+                        "tagCod", tag[0],
+                        "tagNome", tag[1],
+                        "newsCount", tag[2]
+                ))
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(tagsList);
+    }
+}

--- a/back-end/src/main/java/fatec/morpheus/controller/TagFilterController.java
+++ b/back-end/src/main/java/fatec/morpheus/controller/TagFilterController.java
@@ -2,6 +2,9 @@ package fatec.morpheus.controller;
 
 import fatec.morpheus.DTO.TagDTO;
 import fatec.morpheus.service.TagService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,7 +20,11 @@ public class TagFilterController {
 
     @Autowired
     private TagService tagService;
-
+    @Operation(summary = "Metodo para filtrar tags e quantidade de notícias por portais", description = "Filtra tags e quantidade de notícias")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Tags filtradas com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Erro ao filtrar tags"),
+    })
     @PostMapping("/search")
     public ResponseEntity<?> filterTags(@RequestBody List<String> newsSource) {
         if (newsSource == null || newsSource.isEmpty()) {

--- a/back-end/src/main/java/fatec/morpheus/entity/NewsTag.java
+++ b/back-end/src/main/java/fatec/morpheus/entity/NewsTag.java
@@ -1,0 +1,42 @@
+import fatec.morpheus.entity.News;
+import fatec.morpheus.entity.SourceTag;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "news_tag")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class NewsTag {
+
+    @Id
+    @Column(name = "new_cod")
+    private int newCod;
+
+    @Id
+    @Column(name = "src_tag_cod")
+    private int srcTagCod;
+
+    @ManyToOne
+    @JoinColumn(name = "new_cod", referencedColumnName = "new_cod", insertable = false, updatable = false)
+    private News news;
+
+    @ManyToOne
+    @JoinColumn(name = "src_tag_cod", referencedColumnName = "src_tag_cod", insertable = false, updatable = false)
+    private SourceTag sourceTag;
+
+    @Override
+    public String toString() {
+        return "NewsTag{" +
+                "newCod=" + newCod +
+                ", srcTagCod=" + srcTagCod +
+                ", news=" + news +
+                ", sourceTag=" + sourceTag +
+                '}';
+    }
+}

--- a/back-end/src/main/java/fatec/morpheus/service/TagService.java
+++ b/back-end/src/main/java/fatec/morpheus/service/TagService.java
@@ -70,12 +70,15 @@ public class TagService {
         String inClause = "("+String.join(",", newsSource.stream()
                 .map(source -> "'" + source + "'")
                 .toArray(String[]::new))+")";
-        
-        String sql = "SELECT t.tag_name, t.tag_cod, COUNT(n.new_cod) AS quant "+
-                "FROM tag t "+
-                "INNER JOIN source_tag st ON t.tag_cod = st.tag_cod "+
-                "LEFT JOIN news n ON n.new_content LIKE CONCAT('%', t.tag_name, '%') "+
-                "WHERE st.src_cod in"+inClause+
+
+        String sql = "SELECT t.tag_name, t.tag_cod, COUNT(DISTINCT n.new_cod) AS quant " +
+                "FROM tag t " +
+                "INNER JOIN source_tag st ON t.tag_cod = st.tag_cod " +
+                "LEFT JOIN news n ON n.new_content LIKE CONCAT('%', t.tag_name, '%') " +
+                "LEFT JOIN synonymous s ON s.syn_group = t.tag_cod " +
+                "LEFT JOIN text syn_text ON syn_text.text_cod = s.text_cod " +
+                "LEFT JOIN news n_syn ON n_syn.new_content LIKE CONCAT('%', syn_text.text_cod, '%') " +
+                "WHERE st.src_cod in "+inClause+
                 " GROUP BY t.tag_name, t.tag_cod";
         Query query = entityManager.createNativeQuery(sql);
         return query.getResultList();

--- a/back-end/src/main/java/fatec/morpheus/service/TagService.java
+++ b/back-end/src/main/java/fatec/morpheus/service/TagService.java
@@ -73,11 +73,11 @@ public class TagService {
 
         String sql = "select t.tag_cod, tag_name, (select count(nt.new_cod) " +
                 "from news_tag nt " +
-                "inner join source_tag st on st.tag_cod = nt.src_tag_cod " +
-                "where st.src_tag_cod in "+inClause+" ) as quant " +
+                "inner join source_tag st on st.src_tag_cod = nt.src_tag_cod " +
+                "where st.src_cod in "+inClause+" ) as quant " +
                 "from source_tag st " +
                 "inner join tag t on t.tag_cod = st.tag_cod " +
-                "where st.src_tag_cod in "+inClause;
+                "where st.src_cod in "+inClause;
         Query query = entityManager.createNativeQuery(sql);
         return query.getResultList();
     }

--- a/back-end/src/main/java/fatec/morpheus/service/TagService.java
+++ b/back-end/src/main/java/fatec/morpheus/service/TagService.java
@@ -3,6 +3,9 @@ package fatec.morpheus.service;
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -13,8 +16,10 @@ import fatec.morpheus.repository.TagRepository;
 public class TagService {
 
     @Autowired
-    TagRepository tagRepository;
+    private TagRepository tagRepository;
 
+    @PersistenceContext
+    private EntityManager entityManager;
 
     public void saveTag(Tag tag){
         tagRepository.save(tag);
@@ -26,7 +31,7 @@ public class TagService {
 
     public Optional<Tag> tagFindByName(String name){
         return tagRepository.findByTagName(name);
-    }   
+    }
 
     public List<Tag> tagFindAll() {
         return tagRepository.findAll();
@@ -34,7 +39,7 @@ public class TagService {
 
     public Optional<Tag> updateTag(Integer id, Tag updatedTag) {
         Optional<Tag> existingTag = tagRepository.findById(id);
-        
+
         if (existingTag.isPresent()) {
             Tag tagToUpdate = existingTag.get();
             tagToUpdate.setTagName(updatedTag.getTagName());
@@ -49,20 +54,32 @@ public class TagService {
     public Tag createTag(Tag tag){
         Tag savedTag = tagRepository.save(tag);
         return savedTag;
-
     }
 
     public boolean deleTag(Integer id){
-
         if (tagRepository.existsById(id)) {
             tagRepository.deleteById(id);
             return true;
-        }else{
+        } else {
             return false;
         }
     }
 
-    
 
+    public List findTagWithSource(List<String> newsSource) {
+        String inClause = "("+String.join(",", newsSource.stream()
+                .map(source -> "'" + source + "'")
+                .toArray(String[]::new))+")";
+
+        String sql = "select t.tag_cod, tag_name, (select count(nt.new_cod) " +
+                "from news_tag nt " +
+                "inner join source_tag st on st.tag_cod = nt.src_tag_cod " +
+                "where st.src_tag_cod in "+inClause+" ) as quant " +
+                "from source_tag st " +
+                "inner join tag t on t.tag_cod = st.tag_cod " +
+                "where st.src_tag_cod in "+inClause;
+        Query query = entityManager.createNativeQuery(sql);
+        return query.getResultList();
+    }
 
 }

--- a/back-end/src/main/java/fatec/morpheus/service/TagService.java
+++ b/back-end/src/main/java/fatec/morpheus/service/TagService.java
@@ -70,14 +70,13 @@ public class TagService {
         String inClause = "("+String.join(",", newsSource.stream()
                 .map(source -> "'" + source + "'")
                 .toArray(String[]::new))+")";
-
-        String sql = "select t.tag_cod, tag_name, (select count(nt.new_cod) " +
-                "from news_tag nt " +
-                "inner join source_tag st on st.src_tag_cod = nt.src_tag_cod " +
-                "where st.src_cod in "+inClause+" ) as quant " +
-                "from source_tag st " +
-                "inner join tag t on t.tag_cod = st.tag_cod " +
-                "where st.src_cod in "+inClause;
+        
+        String sql = "SELECT t.tag_name, t.tag_cod, COUNT(n.new_cod) AS quant "+
+                "FROM tag t "+
+                "INNER JOIN source_tag st ON t.tag_cod = st.tag_cod "+
+                "LEFT JOIN news n ON n.new_content LIKE CONCAT('%', t.tag_name, '%') "+
+                "WHERE st.src_cod in"+inClause+
+                " GROUP BY t.tag_name, t.tag_cod";
         Query query = entityManager.createNativeQuery(sql);
         return query.getResultList();
     }

--- a/back-end/src/main/resources/application.properties
+++ b/back-end/src/main/resources/application.properties
@@ -1,25 +1,17 @@
-# Updated by Spring Boot
-# Sun Oct 20 19:47:37 BRT 2024
-
-# Cron settings
+#Atualizado pelo Spring Boot
+#Fri Nov 08 01:03:56 BRT 2024
 cron.active=true
-cron.expression=0 48 19 * * *
+cron.expression=0 04 01 * * *
 cron.frequency=Daily
-cron.time=19\:48
+cron.time=01\:04
 cron.timeZone=America/Sao_Paulo
-
-# Spring Cloud Config
 spring.cloud.config.enabled=false
-
-# DataSource settings
+spring.cloud.config.import-check.enabled=false
+spring.config.import=optional\:configserver\:http\://localhost\:8888
+spring.datasource.password=1234
 spring.datasource.url=jdbc\:mysql\://localhost\:3306/morpheus
 spring.datasource.username=root
-spring.datasource.password=root
-
-# JPA settings
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 spring.jpa.show-sql=true
-
-# Spring main settings
 spring.main.allow-circular-references=true


### PR DESCRIPTION
- Criação de método POST para filtrar tags a partir de portais de notícias, buscando quantidade de notícias relacionadas a cada tag. 

- Endpoint do método: "morpheus/tag/search"
- Método possui request payload com lista de ids de portais:
[
    "1",
    "2",
    "3"
]

- Retorna response payload com lista de id de tags, seu nome e quantidade de notícias:
[
    {
        "tagCod": 1,
        "newsCount": 0,
        "tagNome": "Botafogo"
    },
    {
        "tagCod": 2,
        "newsCount": 0,
        "tagNome": "Trump"
    }
]