### PR TITLE
[Aprimoramento técnico] Correção do CRUD de APIs #138

### DIFF
--- a/back-end/src/main/java/fatec/morpheus/DTO/ApiDTO.java
+++ b/back-end/src/main/java/fatec/morpheus/DTO/ApiDTO.java
@@ -1,5 +1,7 @@
 package fatec.morpheus.DTO;
 
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +12,8 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ApiDTO {
-    private int code;
-    private String name;
     private String address;
+    private int get;
+    private int post;
+    private List<Integer> tagCodes;
 }

--- a/back-end/src/main/java/fatec/morpheus/entity/Api.java
+++ b/back-end/src/main/java/fatec/morpheus/entity/Api.java
@@ -1,6 +1,11 @@
 package fatec.morpheus.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -18,11 +23,36 @@ public class Api {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "api_cod")
     private int code;
-    @Column(name = "api_name", length = 30, unique = true)
-    @Size(max = 30, message = "Name cannot exceed 30 characters")
-    private String name;
+
     @Column(name = "api_url", length = 500, unique = true)
     @Size(max = 150, message = "API Address cannot exceed 150 characters")
     private String address;
 
+    @Column(name = "api_post")
+    @Min(value = 0, message = "Post value must be 0 or 1")
+    @Max(value = 1, message = "Post value must be 0 or 1")
+    private int post;
+    
+    @Column(name = "api_get")
+    @Min(value = 0, message = "Get value must be 0 or 1")
+    @Max(value = 1, message = "Get value must be 0 or 1")
+    private int get;
+
+    @Transient
+    public List<Integer> getTagCodes() {
+        return tagCodes;
+    }
+
+    @ElementCollection
+    @CollectionTable(name = "Api_tag", joinColumns = @JoinColumn(name = "src_cod"))
+    @Column(name = "tag_cod")
+    private List<Integer> tagCodes;
+
+    public void setTagCodes(List<Integer> tagCodes) {
+        if (tagCodes != null) {
+            this.tagCodes = new ArrayList<>(tagCodes);
+        } else {
+            this.tagCodes = new ArrayList<>();
+        }
+    }
 }

--- a/back-end/src/main/java/fatec/morpheus/repository/ApiRepository.java
+++ b/back-end/src/main/java/fatec/morpheus/repository/ApiRepository.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ApiRepository extends JpaRepository<Api, Integer> {
-    boolean existsByName(String name);
     boolean existsByAddress(String address);
     Api findByCode(int code);
 }

--- a/back-end/src/main/java/fatec/morpheus/service/ApiService.java
+++ b/back-end/src/main/java/fatec/morpheus/service/ApiService.java
@@ -7,6 +7,7 @@ import fatec.morpheus.exception.InvalidFieldException;
 import fatec.morpheus.exception.NotFoundException;
 import fatec.morpheus.exception.UniqueConstraintViolationException;
 import fatec.morpheus.repository.ApiRepository;
+import jakarta.transaction.Transactional;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,9 +31,10 @@ public class ApiService {
     public Api createApi(ApiDTO apiCreatedDTO) {
         Api api = new Api();
 
-        api.setCode(apiCreatedDTO.getCode());
-        api.setName(apiCreatedDTO.getName());
         api.setAddress(apiCreatedDTO.getAddress());
+        api.setGet(apiCreatedDTO.getGet());
+        api.setPost(apiCreatedDTO.getPost());
+        api.setTagCodes(apiCreatedDTO.getTagCodes());
 
         Set<ConstraintViolation<Api>> sourceViolations = validator.validate(api);
         if (!sourceViolations.isEmpty()) {
@@ -75,9 +77,6 @@ public class ApiService {
 
     private List<String> verifyUniqueKeys(Api api) {
         List<String> duplicateFields = new ArrayList<>();
-        if (apiRepository.existsByName(api.getName())) {
-            duplicateFields.add("name");
-        }
         if (apiRepository.existsByAddress(api.getAddress())) {
             duplicateFields.add("address");
         }
@@ -96,9 +95,9 @@ public class ApiService {
         try {
             return apiRepository.findById(id)
                     .map(existingApi -> {
-                        existingApi.setCode(id);
-                        existingApi.setName(apiToUpdate.getName());
                         existingApi.setAddress(apiToUpdate.getAddress());
+                        existingApi.setGet(apiToUpdate.getGet());
+                        existingApi.setPost(apiToUpdate.getPost());
                         return apiRepository.save(existingApi);
                     })
                     .orElseThrow(() -> new NotFoundException(id, "API"));
@@ -112,7 +111,6 @@ public class ApiService {
             throw new UniqueConstraintViolationException(errorResponse);
         }
     }
-
 
     public Api deleteApiById(int id) {
         Api api = apiRepository.findById(id)

--- a/back-end/src/main/java/fatec/morpheus/service/ApiService.java
+++ b/back-end/src/main/java/fatec/morpheus/service/ApiService.java
@@ -3,6 +3,7 @@ package fatec.morpheus.service;
 import fatec.morpheus.DTO.ApiDTO;
 import fatec.morpheus.entity.Api;
 import fatec.morpheus.entity.ErrorResponse;
+import fatec.morpheus.entity.NewsSource;
 import fatec.morpheus.exception.InvalidFieldException;
 import fatec.morpheus.exception.NotFoundException;
 import fatec.morpheus.exception.UniqueConstraintViolationException;
@@ -10,6 +11,8 @@ import fatec.morpheus.repository.ApiRepository;
 import jakarta.transaction.Transactional;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
+
+import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -115,7 +118,9 @@ public class ApiService {
 
     public Api deleteApiById(int id) {
         Api api = apiRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException(id, "Fonte de Notícia"));
+                .orElseThrow(() -> new NotFoundException(id, "API"));    
+        Hibernate.initialize(api.getTagCodes());
+
         apiRepository.delete(api);
         return api;
     }

--- a/back-end/src/main/java/fatec/morpheus/service/ApiService.java
+++ b/back-end/src/main/java/fatec/morpheus/service/ApiService.java
@@ -98,6 +98,7 @@ public class ApiService {
                         existingApi.setAddress(apiToUpdate.getAddress());
                         existingApi.setGet(apiToUpdate.getGet());
                         existingApi.setPost(apiToUpdate.getPost());
+                        existingApi.setTagCodes(apiToUpdate.getTagCodes());
                         return apiRepository.save(existingApi);
                     })
                     .orElseThrow(() -> new NotFoundException(id, "API"));


### PR DESCRIPTION
Correção do CRUD de APIs implementando os atributos GET e POST e relacionando a API com suas tags.

- POST

Request:
{
  "address": "string",
  "get": 0,
  "post": 0,
  "tagCodes": [
    0
  ]
}