### PR TITLE
 [Aprimoramento técnico] Tratamento de Erros de Exclusão em Cascata #129

### DIFF
--- a/back-end/src/main/java/fatec/morpheus/config/DatabaseConfig.java
+++ b/back-end/src/main/java/fatec/morpheus/config/DatabaseConfig.java
@@ -1,0 +1,42 @@
+package fatec.morpheus.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+
+@Component
+public class DatabaseConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @PostConstruct
+    public void init() {
+        transactionTemplate.execute(status -> {
+
+            List<String> foreignKeys = entityManager.createNativeQuery(
+                "SELECT CONSTRAINT_NAME " +
+                "FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE " +
+                "WHERE TABLE_NAME = 'source_tag' AND COLUMN_NAME = 'tag_cod' AND CONSTRAINT_SCHEMA = DATABASE()"
+            ).getResultList();
+
+            for (String foreignKey : foreignKeys) {
+                entityManager.createNativeQuery("ALTER TABLE source_tag DROP FOREIGN KEY " + foreignKey).executeUpdate();
+            }
+
+            entityManager.createNativeQuery(
+                "ALTER TABLE source_tag ADD CONSTRAINT FK_tag_cod_source_tag FOREIGN KEY (tag_cod) REFERENCES tag(tag_cod) ON DELETE CASCADE"
+            ).executeUpdate();
+
+            return null;
+        });
+    }
+}

--- a/back-end/src/main/java/fatec/morpheus/config/DatabaseConfig.java
+++ b/back-end/src/main/java/fatec/morpheus/config/DatabaseConfig.java
@@ -22,18 +22,34 @@ public class DatabaseConfig {
     public void init() {
         transactionTemplate.execute(status -> {
 
-            List<String> foreignKeys = entityManager.createNativeQuery(
+
+            List<String> foreignKeysSourceTag = entityManager.createNativeQuery(
                 "SELECT CONSTRAINT_NAME " +
                 "FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE " +
                 "WHERE TABLE_NAME = 'source_tag' AND COLUMN_NAME = 'tag_cod' AND CONSTRAINT_SCHEMA = DATABASE()"
             ).getResultList();
 
-            for (String foreignKey : foreignKeys) {
+            for (String foreignKey : foreignKeysSourceTag) {
                 entityManager.createNativeQuery("ALTER TABLE source_tag DROP FOREIGN KEY " + foreignKey).executeUpdate();
             }
 
             entityManager.createNativeQuery(
                 "ALTER TABLE source_tag ADD CONSTRAINT FK_tag_cod_source_tag FOREIGN KEY (tag_cod) REFERENCES tag(tag_cod) ON DELETE CASCADE"
+            ).executeUpdate();
+
+
+            List<String> foreignKeysNews = entityManager.createNativeQuery(
+                "SELECT CONSTRAINT_NAME " +
+                "FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE " +
+                "WHERE TABLE_NAME = 'news' AND COLUMN_NAME = 'new_src_cod' AND CONSTRAINT_SCHEMA = DATABASE()"
+            ).getResultList();
+
+            for (String foreignKey : foreignKeysNews) {
+                entityManager.createNativeQuery("ALTER TABLE news DROP FOREIGN KEY " + foreignKey).executeUpdate();
+            }
+
+            entityManager.createNativeQuery(
+                "ALTER TABLE news ADD CONSTRAINT FK_new_src_cod_news FOREIGN KEY (new_src_cod) REFERENCES source(src_cod) ON DELETE CASCADE"
             ).executeUpdate();
 
             return null;

--- a/back-end/src/main/resources/application.properties
+++ b/back-end/src/main/resources/application.properties
@@ -1,11 +1,11 @@
 #Atualizado pelo Spring Boot
-#Fri Nov 08 01:03:56 BRT 2024
+#Thu Nov 28 19:57:34 BRT 2024
 cron.active=true
-cron.expression=0 04 01 * * *
+cron.expression=0 58 19 * * *
 cron.frequency=Daily
-cron.time=01\:04
+cron.time=19\:58
 cron.timeZone=America/Sao_Paulo
-cron.timeout=5000
+cron.timeout=15000
 spring.cloud.config.enabled=false
 spring.cloud.config.import-check.enabled=false
 spring.config.import=optional\:configserver\:http\://localhost\:8888
@@ -16,3 +16,8 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 spring.jpa.show-sql=true
 spring.main.allow-circular-references=true
+
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.hbm2ddl.auto=update
+

--- a/front-end/html/index.html
+++ b/front-end/html/index.html
@@ -364,7 +364,7 @@
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
-                        Você tem certeza de que deseja excluir {{this.tags.delete.tagSelected.tagName}}?
+                        A tag <strong>{{this.tags.delete.tagSelected.tagName}}</strong> pode estar vinculada há algum portal de notícia. Você tem certeza de que deseja excluir ?
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
@@ -528,7 +528,7 @@
                     <div v-if="cron.isSubmited && !cron.timeout">
                         <span class="text-danger">Este campo é obrigatório.</span>
                     </div>
-        
+                </div>
                 <button class="btn btn-success mt-3" @click="cronSalvarConfiguracao">Salvar</button>
             </div>
         </div>
@@ -645,7 +645,7 @@
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
-                        Você tem certeza de que deseja excluir {{regionalism.delete.wordSelected.content}}?
+                        <strong>{{regionalism.delete.wordSelected.content}}</strong> pode ser sinônimo de outro texto. Você tem certeza de que deseja exclui-lo?
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" @click="cancelDeleteWord()">Cancelar</button>

--- a/front-end/html/index.html
+++ b/front-end/html/index.html
@@ -260,7 +260,7 @@
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
-                        Você tem certeza de que deseja excluir {{this.sourceNews.delete.sourceSelected.name}}?
+                        O portal <strong>{{this.sourceNews.delete.sourceSelected.name}}</strong> pode estar vinculado a alguma notícia. Você tem certeza de que deseja excluí-lo?
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
@@ -645,7 +645,7 @@
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
-                        <strong>{{regionalism.delete.wordSelected.content}}</strong> pode ser sinônimo de outro texto. Você tem certeza de que deseja exclui-lo?
+                        <strong>{{regionalism.delete.wordSelected.content}}</strong> pode ser sinônimo de outro texto. Você tem certeza de que deseja excluí-lo?
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" @click="cancelDeleteWord()">Cancelar</button>

--- a/front-end/html/index.html
+++ b/front-end/html/index.html
@@ -260,7 +260,7 @@
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
-                        O portal <strong>{{this.sourceNews.delete.sourceSelected.name}}</strong> pode estar vinculado a alguma notícia. Você tem certeza de que deseja excluí-lo?
+                        Se excluir o portal <strong>{{this.sourceNews.delete.sourceSelected.name}}</strong> as notícias vinculadas a ele serão deletadas. Você tem certeza de que deseja excluí-lo?
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>


### PR DESCRIPTION
Alterada a estrutura das tabelas para permitir a exclusão de registros de tags, portais de notícias e textos, mesmo com relacionamentos existentes em outras tabelas. Implementada a opção ON DELETE CASCADE nas chaves estrangeiras pertinentes, garantindo a consistência dos dados ao remover esses registros.